### PR TITLE
Create offers table layout

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,11 +1,22 @@
 <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="64" height="64" rx="12" fill="url(#gradient)"/>
-  <circle cx="32" cy="32" r="22" stroke="white" stroke-width="3"/>
-  <path d="M24 22L42 32L24 42V22Z" fill="white"/>
   <defs>
-    <linearGradient id="gradient" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#667eea"/>
-      <stop offset="100%" stop-color="#764ba2"/>
+    <linearGradient id="tealTop" x1="8" y1="10" x2="56" y2="10" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1DD3D7"/>
+      <stop offset="1" stop-color="#0B6C8E"/>
+    </linearGradient>
+    <linearGradient id="tealWaves" x1="12" y1="36" x2="52" y2="52" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1DD3D7"/>
+      <stop offset="1" stop-color="#0B4F72"/>
+    </linearGradient>
+    <linearGradient id="drop" x1="32" y1="14" x2="32" y2="36" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F59A2E"/>
+      <stop offset="1" stop-color="#C86A12"/>
     </linearGradient>
   </defs>
+  <rect width="64" height="64" rx="16" fill="#F2FBFF"/>
+  <path d="M16 24c0-6.5 5.6-12 16-12h0c10.4 0 16 5.5 16 12" stroke="url(#tealTop)" stroke-width="4.5" stroke-linecap="round"/>
+  <path d="M24 28c3.3 1.8 6.7 2.7 10 2.7 3.3 0 6.7-.9 10-2.7" stroke="url(#tealWaves)" stroke-width="4.2" stroke-linecap="round"/>
+  <path d="M18 34c4 2.3 9.3 3.5 14 3.5s10-.9 14-3.5" stroke="url(#tealWaves)" stroke-width="4.2" stroke-linecap="round"/>
+  <path d="M20 40c4.6 3.5 10.4 5 12 5s7.4-1.5 12-5" stroke="url(#tealWaves)" stroke-width="4.2" stroke-linecap="round"/>
+  <path d="M32 12c-3.5 4.8-6 8.8-6 12.5 0 3.5 2.7 6.5 6 6.5s6-3 6-6.5c0-3.7-2.5-7.7-6-12.5Z" fill="url(#drop)"/>
 </svg>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,45 +1,251 @@
-import { useEffect } from 'react';
-import Navbar from './components/Navbar';
-import Hero from './components/Hero';
-import Features from './components/Features';
-import HowItWorks from './components/HowItWorks';
-import Stats from './components/Stats';
-import CTA from './components/CTA';
-import Footer from './components/Footer';
+const offers = [
+  {
+    name: 'NiftyBruh.eth',
+    avatar: '🌀',
+    avatarColor: '#d8e8ff',
+    asset: '1 ETH',
+    chain: 'BASE',
+    accepts: ['ETH', 'ARB', 'BTC', 'CELO'],
+    partial: true,
+    status: 0,
+    premium: '1%',
+    orderId: '#33',
+  },
+  {
+    name: 'HanweChang.eth',
+    avatar: '🧠',
+    avatarColor: '#ffe2c6',
+    asset: '10 BTC',
+    chain: 'BTC',
+    accepts: ['BTC', 'SOL', 'CELO', 'ARB'],
+    partial: true,
+    status: 50,
+    premium: '3.5%',
+    orderId: '#52',
+  },
+  {
+    name: 'Tacoman.eth',
+    avatar: '🌮',
+    avatarColor: '#ffeac2',
+    asset: '1 NFT',
+    chain: 'ARB',
+    accepts: ['ARB', 'BTC', 'CELO'],
+    partial: false,
+    status: 0,
+    premium: '5%',
+    orderId: '#123',
+  },
+  {
+    name: '0xAB5....39c81',
+    avatar: '🛡️',
+    avatarColor: '#ffe7d9',
+    asset: '1000 USDC',
+    chain: 'ARB',
+    accepts: ['ARB', 'ETH', 'CELO', 'SOL'],
+    partial: false,
+    status: 25,
+    premium: '2%',
+    orderId: '#187',
+  },
+  {
+    name: 'HunterBeast.eth',
+    avatar: '🐾',
+    avatarColor: '#d9ecff',
+    asset: '123 Matic',
+    chain: 'MATIC',
+    accepts: ['ARB', 'SOL', 'BTC'],
+    partial: true,
+    status: 75,
+    premium: '.05%',
+    orderId: '#321',
+  },
+  {
+    name: 'HunterBeast.eth',
+    avatar: '🐾',
+    avatarColor: '#d9ecff',
+    asset: '33k CELO',
+    chain: 'CELO',
+    accepts: ['CELO', 'SOL', 'ETH'],
+    partial: true,
+    status: 0,
+    premium: '.25%',
+    orderId: '#222',
+  },
+  {
+    name: '0xE66....330EA',
+    avatar: '✨',
+    avatarColor: '#fff4d9',
+    asset: '50k USDC',
+    chain: 'MATIC',
+    accepts: ['ARB', 'SOL', 'ETH'],
+    partial: false,
+    status: 50,
+    premium: '2.2%',
+    orderId: '#333',
+  },
+  {
+    name: 'CryptoBabe.eth',
+    avatar: '🧜‍♀️',
+    avatarColor: '#d9f2ff',
+    asset: '101 CELO',
+    chain: 'CELO',
+    accepts: ['CELO', 'ARB', 'BTC'],
+    partial: false,
+    status: 0,
+    premium: '.03%',
+    orderId: '#69',
+  },
+  {
+    name: 'Domo.eth',
+    avatar: '🤖',
+    avatarColor: '#f2f2f2',
+    asset: '20 ETH',
+    chain: 'ETH',
+    accepts: ['BTC', 'ARB', 'SOL'],
+    partial: true,
+    status: 75,
+    premium: '.11%',
+    orderId: '#1111',
+  },
+  {
+    name: 'Frogger.eth',
+    avatar: '🐸',
+    avatarColor: '#dff7d1',
+    asset: '50 Matic',
+    chain: 'MATIC',
+    accepts: ['CELO', 'ARB'],
+    partial: true,
+    status: 0,
+    premium: '.01%',
+    orderId: '#1234',
+  },
+];
 
-function App() {
-  useEffect(() => {
-    // Navbar scroll effect
-    const handleScroll = () => {
-      const navbar = document.querySelector('.navbar');
-      const currentScroll = window.scrollY;
-      
-      if (currentScroll > 100) {
-        navbar.style.background = 'rgba(15, 15, 30, 0.98)';
-        navbar.style.boxShadow = '0 2px 20px rgba(0, 0, 0, 0.3)';
-      } else {
-        navbar.style.background = 'rgba(15, 15, 30, 0.95)';
-        navbar.style.boxShadow = 'none';
-      }
-    };
+const chainThemes = {
+  BASE: { label: 'BASE', background: 'linear-gradient(135deg, #1dd3d7, #0b6c8e)', textColor: '#f6fbff' },
+  BTC: { label: 'BTC', background: 'linear-gradient(135deg, #f59a2e, #c86a12)', textColor: '#3b2000' },
+  ARB: { label: 'ARB', background: 'linear-gradient(135deg, #0b6c8e, #0b4f72)', textColor: '#e4f6ff' },
+  CELO: { label: 'CELO', background: 'linear-gradient(135deg, #1dd3d7, #0f92b4)', textColor: '#083142' },
+  SOL: { label: 'SOL', background: 'linear-gradient(135deg, #0b4f72, #0f92b4)', textColor: '#e2f4ff' },
+  MATIC: { label: 'MATIC', background: 'linear-gradient(135deg, #0f92b4, #1dd3d7)', textColor: '#083142' },
+  ETH: { label: 'ETH', background: 'linear-gradient(135deg, #e9f6ff, #c9e9f7)', textColor: '#0b3c54' },
+};
 
-    window.addEventListener('scroll', handleScroll);
-    
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-    };
-  }, []);
+function Avatar({ symbol, color }) {
+  return (
+    <div className="avatar" style={{ backgroundColor: color }}>
+      <span>{symbol}</span>
+    </div>
+  );
+}
+
+function TokenBadge({ token }) {
+  const theme = chainThemes[token] || chainThemes.ETH;
+  return (
+    <div className="token-badge" style={{ background: theme.background, color: theme.textColor }}>
+      {theme.label}
+    </div>
+  );
+}
+
+function StatusCell({ percent }) {
+  if (!percent) return <span className="status-zero">0%</span>;
 
   return (
-    <>
-      <Navbar />
-      <Hero />
-      <Features />
-      <HowItWorks />
-      <Stats />
-      <CTA />
-      <Footer />
-    </>
+    <div className="status-indicator" aria-label={`Status ${percent}%`}>
+      <div
+        className="status-ring"
+        style={{ background: `conic-gradient(#5bc35b ${percent}%, #e8e8e8 ${percent}%)` }}
+      >
+        <span>{percent}%</span>
+      </div>
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <div className="app-shell">
+      <header className="top-bar">
+        <div className="logo-mark" aria-label="Liquid Nation logo">
+          <img src="/favicon.svg" alt="Liquid Nation" />
+        </div>
+        <div className="wallet-pill">0x123...</div>
+      </header>
+
+      <main className="main-stage">
+        <section className="offers-panel" aria-label="Open offers">
+          <div className="panel-header">
+            <h1>Open Offers</h1>
+          </div>
+
+          <div className="table">
+            <div className="table-row table-head">
+              <div className="table-cell">Profile</div>
+              <div className="table-cell">Asset</div>
+              <div className="table-cell">Chain</div>
+              <div className="table-cell">Accepts</div>
+              <div className="table-cell">Partial</div>
+              <div className="table-cell">Status</div>
+              <div className="table-cell">Premium</div>
+              <div className="table-cell">Order ID</div>
+            </div>
+
+            {offers.map((offer) => (
+              <div className="table-row" key={`${offer.name}-${offer.orderId}`}>
+                <div className="table-cell profile-cell">
+                  <Avatar symbol={offer.avatar} color={offer.avatarColor} />
+                  <span className="profile-name">{offer.name}</span>
+                </div>
+                <div className="table-cell text-strong">{offer.asset}</div>
+                <div className="table-cell">
+                  <TokenBadge token={offer.chain} />
+                </div>
+                <div className="table-cell accepts-cell">
+                  {offer.accepts.map((token) => (
+                    <TokenBadge key={`${offer.orderId}-${token}`} token={token} />
+                  ))}
+                </div>
+                <div className="table-cell text-strong">{offer.partial ? 'Yes' : 'No'}</div>
+                <div className="table-cell">
+                  <StatusCell percent={offer.status} />
+                </div>
+                <div className="table-cell text-strong">{offer.premium}</div>
+                <div className="table-cell order-id">{offer.orderId}</div>
+              </div>
+            ))}
+          </div>
+
+          <div className="panel-footer">
+            <div className="footer-actions" aria-label="Table actions">
+              <button type="button" className="icon-button" aria-label="Resize">
+                ☐
+              </button>
+              <button type="button" className="icon-button" aria-label="Refresh">
+                ↻
+              </button>
+            </div>
+
+            <div className="pagination">
+              <div className="per-page">Orders Per Page:</div>
+              <div className="dropdown">10 ▼</div>
+              <div className="page-window">1-10 of 92</div>
+              <div className="pager-arrows">
+                <button type="button" aria-label="Previous page">‹</button>
+                <button type="button" aria-label="Next page">›</button>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <nav className="bottom-nav" aria-label="Primary">
+        <a className="nav-item" href="#">Dashboard</a>
+        <a className="nav-item active" href="#">Offers</a>
+        <a className="nav-item" href="#">Create</a>
+        <a className="nav-item" href="#">Settings</a>
+      </nav>
+    </div>
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,561 +1,267 @@
-/* Reset and Base Styles */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
 :root {
-    --primary-color: #667eea;
-    --secondary-color: #764ba2;
-    --dark-bg: #0f0f1e;
-    --card-bg: #1a1a2e;
-    --text-primary: #ffffff;
-    --text-secondary: #b4b4c8;
-    --border-color: #2d2d44;
-    --gradient: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    --shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+  --bg: linear-gradient(180deg, #d9f6ff 0%, #9bdff7 45%, #6fc7ec 100%);
+  --panel: #f6fbff;
+  --panel-shadow: 0 16px 40px rgba(7, 83, 114, 0.16);
+  --border: #c8e3ef;
+  --text-strong: #0b3c54;
+  --text-subtle: #3f6b7a;
+  --nav-bg: #0b4f72;
+  --nav-active: #f59a2e;
+  --accent: #1dd3d7;
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-    background: var(--dark-bg);
-    color: var(--text-primary);
-    line-height: 1.6;
-    overflow-x: hidden;
-}
-
-.container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 20px;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--bg);
+  color: var(--text-strong);
+  min-height: 100vh;
 }
 
-/* Navigation */
-.navbar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    background: rgba(15, 15, 30, 0.95);
-    backdrop-filter: blur(10px);
-    border-bottom: 1px solid var(--border-color);
-    z-index: 1000;
-    padding: 1rem 0;
+#root {
+  width: 100%;
 }
 
-.nav-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+.app-shell {
+  max-width: 1200px;
+  margin: 48px auto 0;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 16px;
+  padding-bottom: 96px;
 }
 
-.logo {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    font-size: 1.5rem;
-    font-weight: 700;
-    cursor: pointer;
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
-.logo-text {
-    background: var(--gradient);
-    background-clip: text;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
+.logo-mark img {
+  width: 96px;
+  height: auto;
 }
 
-.nav-links {
-    display: flex;
-    align-items: center;
-    gap: 2rem;
+.wallet-pill {
+  background: linear-gradient(135deg, #0b6c8e, #0b4f72);
+  color: #fdfaf4;
+  padding: 10px 22px;
+  border-radius: 22px;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  box-shadow: 0 10px 26px rgba(7, 83, 114, 0.25);
 }
 
-.nav-links a {
-    color: var(--text-secondary);
-    text-decoration: none;
-    font-weight: 500;
-    transition: color 0.3s ease;
+.main-stage {
+  display: flex;
+  justify-content: center;
 }
 
-.nav-links a:hover {
-    color: var(--text-primary);
+.offers-panel {
+  width: 100%;
+  background: var(--panel);
+  border-radius: 18px;
+  box-shadow: var(--panel-shadow);
+  border: 1px solid var(--border);
+  overflow: hidden;
 }
 
-.mobile-menu-toggle {
-    display: none;
-    flex-direction: column;
-    gap: 5px;
-    cursor: pointer;
+.panel-header {
+  padding: 18px 20px 12px;
+  border-bottom: 1px solid var(--border);
 }
 
-.mobile-menu-toggle span {
-    width: 25px;
-    height: 3px;
-    background: var(--text-primary);
-    border-radius: 3px;
-    transition: all 0.3s ease;
+.panel-header h1 {
+  font-size: 24px;
+  font-weight: 800;
+  color: var(--text-strong);
 }
 
-/* Buttons */
-.btn-primary {
-    background: var(--gradient);
-    color: white;
-    border: none;
-    padding: 12px 24px;
-    border-radius: 8px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+.table {
+  display: grid;
 }
 
-.btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 5px 20px rgba(102, 126, 234, 0.4);
+.table-row {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr 1.4fr 0.8fr 1fr 1fr 0.8fr;
+  align-items: center;
+  padding: 12px 18px;
+  gap: 12px;
+  border-bottom: 1px solid var(--border);
 }
 
-.btn-secondary {
-    background: transparent;
-    color: var(--text-primary);
-    border: 2px solid var(--primary-color);
-    padding: 12px 24px;
-    border-radius: 8px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.3s ease;
+.table-row:nth-child(even) {
+  background: #eaf7ff;
 }
 
-.btn-secondary:hover {
-    background: var(--primary-color);
-    transform: translateY(-2px);
+.table-head {
+  background: transparent;
+  border-bottom: 2px solid var(--border);
+  font-weight: 700;
+  color: var(--text-subtle);
 }
 
-.btn-large {
-    padding: 16px 32px;
-    font-size: 1.1rem;
+.table-cell {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text-subtle);
+  font-weight: 600;
 }
 
-/* Hero Section */
-.hero {
-    margin-top: 80px;
-    padding: 100px 0;
-    text-align: center;
-    position: relative;
-    overflow: hidden;
+.text-strong {
+  color: var(--text-strong);
 }
 
-.hero::before {
-    content: '';
-    position: absolute;
-    top: -50%;
-    left: -50%;
-    width: 200%;
-    height: 200%;
-    background: radial-gradient(circle, rgba(102, 126, 234, 0.1) 0%, transparent 50%);
-    animation: pulse 8s ease-in-out infinite;
+.profile-cell {
+  font-weight: 800;
+  color: var(--text-strong);
 }
 
-@keyframes pulse {
-    0%, 100% { transform: scale(1); opacity: 0.5; }
-    50% { transform: scale(1.1); opacity: 0.8; }
+.avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  border: 2px solid #f6fbff;
 }
 
-.hero-content {
-    position: relative;
-    z-index: 1;
+.token-badge {
+  padding: 8px 12px;
+  border-radius: 999px;
+  font-weight: 800;
+  font-size: 12px;
+  min-width: 64px;
+  text-align: center;
+  box-shadow: inset 0 1px 2px rgba(7, 83, 114, 0.12);
+}
+
+.accepts-cell {
+  flex-wrap: wrap;
+  display: flex;
+  gap: 8px;
 }
 
-.hero-title {
-    font-size: 4rem;
-    font-weight: 800;
-    line-height: 1.2;
-    margin-bottom: 1.5rem;
+.status-zero {
+  font-weight: 700;
+  color: var(--nav-bg);
 }
 
-.gradient-text {
-    background: var(--gradient);
-    background-clip: text;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
+.status-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.hero-description {
-    font-size: 1.3rem;
-    color: var(--text-secondary);
-    max-width: 700px;
-    margin: 0 auto 2.5rem;
+.status-ring {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  color: #f59a2e;
+  font-weight: 700;
+  background: conic-gradient(#f59a2e 0%, #dcecf5 0%);
 }
 
-.hero-buttons {
-    display: flex;
-    gap: 1rem;
-    justify-content: center;
-    margin-bottom: 4rem;
+.order-id {
+  color: #0b4f72;
+  font-weight: 800;
 }
 
-.hero-stats {
-    display: flex;
-    justify-content: center;
-    gap: 4rem;
-    flex-wrap: wrap;
+.panel-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 18px 16px;
 }
 
-.stat-item {
-    text-align: center;
+.footer-actions {
+  display: flex;
+  gap: 12px;
 }
 
-.stat-value {
-    font-size: 2.5rem;
-    font-weight: 700;
-    background: var(--gradient);
-    background-clip: text;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
+.icon-button {
+  border: 1px solid var(--border);
+  background: #fdfaf4;
+  padding: 8px 12px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 700;
+  color: var(--nav-bg);
+  box-shadow: 0 6px 14px rgba(7, 83, 114, 0.12);
 }
 
-.stat-label {
-    color: var(--text-secondary);
-    font-size: 0.9rem;
-    margin-top: 0.5rem;
+.pagination {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--text-strong);
+  font-weight: 700;
 }
 
-/* Features Section */
-.features {
-    padding: 100px 0;
-    background: linear-gradient(180deg, var(--dark-bg) 0%, var(--card-bg) 100%);
+.dropdown,
+.page-window {
+  border: 1px solid var(--border);
+  background: #fdfaf4;
+  padding: 8px 12px;
+  border-radius: 10px;
+  min-width: 88px;
+  text-align: center;
+  box-shadow: 0 6px 14px rgba(7, 83, 114, 0.12);
 }
 
-.section-title {
-    font-size: 3rem;
-    font-weight: 700;
-    text-align: center;
-    margin-bottom: 1rem;
+.pager-arrows button {
+  border: 1px solid var(--border);
+  background: #fdfaf4;
+  padding: 8px 10px;
+  border-radius: 10px;
+  cursor: pointer;
+  margin-left: 6px;
+  font-size: 16px;
+  box-shadow: 0 6px 14px rgba(7, 83, 114, 0.12);
 }
 
-.section-subtitle {
-    text-align: center;
-    color: var(--text-secondary);
-    font-size: 1.2rem;
-    margin-bottom: 4rem;
+.bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--nav-bg);
+  color: #dbeffc;
+  display: flex;
+  justify-content: center;
+  gap: 80px;
+  padding: 16px 0;
+  font-weight: 700;
 }
 
-.features-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 2rem;
+.nav-item {
+  color: inherit;
+  text-decoration: none;
 }
 
-.feature-card {
-    background: rgba(26, 26, 46, 0.6);
-    border: 1px solid var(--border-color);
-    border-radius: 16px;
-    padding: 2rem;
-    transition: all 0.3s ease;
+.nav-item.active {
+  color: var(--nav-active);
 }
 
-.feature-card:hover {
-    transform: translateY(-5px);
-    border-color: var(--primary-color);
-    box-shadow: var(--shadow);
-}
-
-.feature-icon {
-    margin-bottom: 1.5rem;
-}
-
-.feature-card h3 {
-    font-size: 1.5rem;
-    margin-bottom: 1rem;
-}
-
-.feature-card p {
-    color: var(--text-secondary);
-    line-height: 1.6;
-}
-
-/* How It Works Section */
-.how-it-works {
-    padding: 100px 0;
-    background: var(--card-bg);
-}
-
-.steps {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: 2rem;
-    flex-wrap: wrap;
-    margin-top: 4rem;
-}
-
-.step {
-    text-align: center;
-    max-width: 200px;
-}
-
-.step-number {
-    width: 60px;
-    height: 60px;
-    background: var(--gradient);
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.5rem;
-    font-weight: 700;
-    margin: 0 auto 1rem;
-}
-
-.step h3 {
-    font-size: 1.2rem;
-    margin-bottom: 0.5rem;
-}
-
-.step p {
-    color: var(--text-secondary);
-    font-size: 0.9rem;
-}
-
-.step-arrow {
-    font-size: 2rem;
-    color: var(--primary-color);
-}
-
-/* Stats Section */
-.stats-section {
-    padding: 100px 0;
-    background: var(--dark-bg);
-}
-
-.stats-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 2rem;
-    margin-top: 4rem;
-}
-
-.stat-card {
-    background: rgba(26, 26, 46, 0.6);
-    border: 1px solid var(--border-color);
-    border-radius: 16px;
-    padding: 2rem;
-    text-align: center;
-    transition: all 0.3s ease;
-}
-
-.stat-card:hover {
-    border-color: var(--primary-color);
-    transform: translateY(-5px);
-}
-
-.stat-card-value {
-    font-size: 2.5rem;
-    font-weight: 700;
-    background: var(--gradient);
-    background-clip: text;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    margin-bottom: 0.5rem;
-}
-
-.stat-card-label {
-    color: var(--text-secondary);
-    font-size: 1rem;
-}
-
-/* CTA Section */
-.cta-section {
-    padding: 100px 0;
-    background: linear-gradient(135deg, rgba(102, 126, 234, 0.1) 0%, rgba(118, 75, 162, 0.1) 100%);
-    text-align: center;
-}
-
-.cta-content h2 {
-    font-size: 3rem;
-    margin-bottom: 1rem;
-}
-
-.cta-content p {
-    color: var(--text-secondary);
-    font-size: 1.2rem;
-    margin-bottom: 2rem;
-}
-
-/* Footer */
-.footer {
-    background: var(--card-bg);
-    border-top: 1px solid var(--border-color);
-    padding: 60px 0 30px;
-}
-
-.footer-content {
-    display: grid;
-    grid-template-columns: 2fr 1fr 1fr 1fr;
-    gap: 3rem;
-    margin-bottom: 3rem;
-}
-
-.footer-logo {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    font-size: 1.3rem;
-    font-weight: 700;
-    margin-bottom: 1rem;
-}
-
-.footer-description {
-    color: var(--text-secondary);
-    line-height: 1.6;
-}
-
-.footer-section h4 {
-    margin-bottom: 1rem;
-    font-size: 1.1rem;
-}
-
-.footer-section ul {
-    list-style: none;
-}
-
-.footer-section ul li {
-    margin-bottom: 0.7rem;
-}
-
-.footer-section a {
-    color: var(--text-secondary);
-    text-decoration: none;
-    transition: color 0.3s ease;
-}
-
-.footer-section a:hover {
-    color: var(--text-primary);
-}
-
-.footer-bottom {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding-top: 2rem;
-    border-top: 1px solid var(--border-color);
-    color: var(--text-secondary);
-    font-size: 0.9rem;
-}
-
-.footer-links {
-    display: flex;
-    gap: 2rem;
-}
-
-.footer-links a {
-    color: var(--text-secondary);
-    text-decoration: none;
-}
-
-.footer-links a:hover {
-    color: var(--text-primary);
-}
-
-/* Responsive Design */
-@media (max-width: 968px) {
-    .nav-links {
-        display: none;
-    }
-    
-    .mobile-menu-toggle {
-        display: flex;
-    }
-    
-    .hero-title {
-        font-size: 2.5rem;
-    }
-    
-    .hero-description {
-        font-size: 1.1rem;
-    }
-    
-    .hero-buttons {
-        flex-direction: column;
-        align-items: center;
-    }
-    
-    .hero-stats {
-        gap: 2rem;
-    }
-    
-    .section-title {
-        font-size: 2rem;
-    }
-    
-    .features-grid {
-        grid-template-columns: 1fr;
-    }
-    
-    .step-arrow {
-        display: none;
-    }
-    
-    .footer-content {
-        grid-template-columns: 1fr;
-    }
-    
-    .footer-bottom {
-        flex-direction: column;
-        gap: 1rem;
-        text-align: center;
-    }
-    
-    .cta-content h2 {
-        font-size: 2rem;
-    }
-}
-
-@media (max-width: 600px) {
-    .hero-title {
-        font-size: 2rem;
-    }
-    
-    .stat-value {
-        font-size: 2rem;
-    }
-    
-    .stat-card-value {
-        font-size: 2rem;
-    }
-}
-
-/* Additional React-specific styles */
-@keyframes fadeIn {
-    from { opacity: 0; transform: translate(-50%, -60%); }
-    to { opacity: 1; transform: translate(-50%, -50%); }
-}
-
-@keyframes fadeOut {
-    from { opacity: 1; transform: translate(-50%, -50%); }
-    to { opacity: 0; transform: translate(-50%, -40%); }
-}
-
-.nav-links.active {
-    display: flex;
-    flex-direction: column;
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    background: rgba(15, 15, 30, 0.98);
-    padding: 20px;
-    border-bottom: 1px solid var(--border-color);
-}
-
-.mobile-menu-toggle.active span:nth-child(1) {
-    transform: rotate(45deg) translate(5px, 5px);
-}
-
-.mobile-menu-toggle.active span:nth-child(2) {
-    opacity: 0;
-}
+@media (max-width: 1024px) {
+  .table-row {
+    grid-template-columns: 1.2fr 1fr 1fr 1fr 0.8fr 1fr 1fr 0.8fr;
+  }
 
-.mobile-menu-toggle.active span:nth-child(3) {
-    transform: rotate(-45deg) translate(7px, -6px);
+  .bottom-nav {
+    gap: 32px;
+  }
 }


### PR DESCRIPTION
## Summary
- replace landing page components with a focused offers table layout matching the provided mock
- add styled badges, avatars, and status indicators for offer rows
- recreate styling to mirror the light panel on a blue background with bottom navigation
- adjust page layout so the bottom navigation stays anchored at the viewport edge
- update branding to the new Liquid Nation logo and recolor the UI with the teal/orange palette

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950ba62f2b8832e8a3e53df874cbf67)