### PR TITLE
Default to dark mode on first load

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Liquid Nation - P2P Cross-Chain Exchange Protocol" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <script>
+      (() => {
+        try {
+          const savedTheme = localStorage.getItem('theme');
+          const isDark = savedTheme ? savedTheme === 'dark' : true;
+          document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
+        } catch (error) {
+          document.documentElement.setAttribute('data-theme', 'dark');
+        }
+      })();
+    </script>
     <title>Liquid Nation - P2P Cross-Chain Exchange</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- set the data-theme attribute in the document head before hydration, defaulting to dark mode when no preference is saved
- fall back to dark mode if localStorage is unavailable to keep the default consistent

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69511b4edf58832ea226f2def9218301)